### PR TITLE
28 e archive pages

### DIFF
--- a/app/Http/Controllers/FolderController.php
+++ b/app/Http/Controllers/FolderController.php
@@ -172,6 +172,39 @@ class FolderController extends Controller
         //
     }
 
+    public function getKaurDokumenKepegawaianByWadek()
+    {
+        $user = Auth::user();
+        $role = $user->role;
+
+        if (!in_array($role, ['wadek1', 'wadek2'])) {
+            return response()->json([
+                'error' => 'Access denied'
+            ], 403);
+        }
+
+        $subDivisions = match ($role) {
+            'wadek1' => ['academic_service', 'laboratory'],
+            'wadek2' => ['secretary', 'student_affair', 'finance_logistic_resource'],
+        };
+
+        $subfolders = Folder::where('type', 'kepegawaian')
+            ->whereHas('user', function ($query) use ($subDivisions) {
+                $query->where('role', 'kaur')
+                    ->whereIn('division', $subDivisions);
+            })
+            ->get();
+
+        $folder = Folder::where('user_id', $user->id)
+            ->where('type', 'user')
+            ->first();
+        return Inertia::render('e-archive/staf/pegawai', [
+            'currentFolder' => $folder,
+            'breadcrumbs' => [],
+            'subfolders' => $subfolders,
+            'files' => []
+        ]);
+    }
 
     public function getStafDokumenKepegawaianByWadek()
     {
@@ -206,6 +239,42 @@ class FolderController extends Controller
             'files' => []
         ]);
     }
+
+
+    public function getKaurDokumenKinerjaByWadek()
+    {
+        $user = Auth::user();
+        $role = $user->role;
+
+        if (!in_array($role, ['wadek1', 'wadek2'])) {
+            return response()->json([
+                'error' => 'Access denied'
+            ], 403);
+        }
+
+        $subDivisions = match ($role) {
+            'wadek1' => ['academic_service', 'laboratory'],
+            'wadek2' => ['secretary', 'student_affair', 'finance_logistic_resource'],
+        };
+
+        $subfolders = Folder::where('type', 'kinerja')
+            ->whereHas('user', function ($query) use ($subDivisions) {
+                $query->where('role', 'staf')
+                    ->whereIn('division', $subDivisions);
+            })
+            ->get();
+        $folder = Folder::where('user_id', $user->id)
+            ->where('type', 'user')
+            ->first();
+
+        return Inertia::render('e-archive/staf/kerja', [
+            'currentFolder' => $folder,
+            'breadcrumbs' => [],
+            'subfolders' => $subfolders,
+            'files' => []
+        ]);
+    }
+
 
     public function getStafDokumenKinerjaByWadek()
     {

--- a/app/Http/Controllers/FolderController.php
+++ b/app/Http/Controllers/FolderController.php
@@ -172,6 +172,70 @@ class FolderController extends Controller
         //
     }
 
+
+    public function getMyDocumentKinerja()
+    {
+        $user = Auth::user();
+
+        $folder = Folder::where('user_id', $user->id)
+            ->where('type', 'kinerja')
+            ->first();
+
+
+        $subfolders = Folder::where('parent_id', $folder->id)
+            ->where('user_id', $user->id)
+            ->get();
+
+        $files = File::where('folder_id', $folder->id)
+            ->where('user_id', $user->id)
+            ->get();
+
+        $breadcrumbs = $this->getBreadcrumbs($folder);
+        return Inertia::render('e-archive/staf/kerja', [
+            'currentFolder' => $folder,
+            'breadcrumbs' => $breadcrumbs,
+            'subfolders' => $subfolders,
+            'files' => $files
+        ]);
+    }
+
+    public function getMyDocumentKepegawaian()
+    {
+        $user = Auth::user();
+
+        $folder = Folder::where('user_id', $user->id)
+            ->where('type', 'kepegawaian')
+            ->first();
+
+        if (!$folder) {
+            return Inertia::render('e-archive/staf/pegawai', [
+                'currentFolder' => null,
+                'breadcrumbs' => [],
+                'subfolders' => [],
+                'files' => [],
+                'message' => 'Dokumen kepegawaian tidak ditemukan'
+            ]);
+        }
+
+        $subfolders = Folder::where('parent_id', $folder->id)
+            ->where('user_id', $user->id)
+            ->get();
+
+        $files = File::where('folder_id', $folder->id)
+            ->where('user_id', $user->id)
+            ->get();
+
+        $breadcrumbs = $this->getBreadcrumbs($folder);
+
+        return Inertia::render('e-archive/staf/pegawai', [
+            'currentFolder' => $folder,
+            'breadcrumbs' => $breadcrumbs,
+            'subfolders' => $subfolders,
+            'files' => $files
+        ]);
+    }
+
+
     public function getKaurDokumenKepegawaianByWadek()
     {
         $user = Auth::user();

--- a/app/Http/Controllers/FolderController.php
+++ b/app/Http/Controllers/FolderController.php
@@ -13,6 +13,9 @@ class FolderController extends Controller
     /**
      * Display a listing of the resource.
      */
+
+
+
     public function index()
     {
         $user = Auth::user();
@@ -115,7 +118,7 @@ class FolderController extends Controller
         }
 
         // Cek akses berdasarkan role
-        if ($role === 'wadek') {
+        if ($role === 'wadek1' || $role === 'wadek2') {
             // Wadek bisa akses semua folder
         } elseif ($role === 'kaur') {
             // Kaur hanya bisa akses folder user satu divisi
@@ -168,6 +171,77 @@ class FolderController extends Controller
     {
         //
     }
+
+
+    public function getStafDokumenKepegawaianByWadek()
+    {
+        $user = Auth::user();
+        $role = $user->role;
+
+        if (!in_array($role, ['wadek1', 'wadek2'])) {
+            return response()->json([
+                'error' => 'Access denied'
+            ], 403);
+        }
+
+        $subDivisions = match ($role) {
+            'wadek1' => ['academic_service', 'laboratory'],
+            'wadek2' => ['secretary', 'student_affair', 'finance_logistic_resource'],
+        };
+
+        $subfolders = Folder::where('type', 'kepegawaian')
+            ->whereHas('user', function ($query) use ($subDivisions) {
+                $query->where('role', 'staf')
+                    ->whereIn('division', $subDivisions);
+            })
+            ->get();
+
+        $folder = Folder::where('user_id', $user->id)
+            ->where('type', 'user')
+            ->first();
+        return Inertia::render('e-archive/staf/pegawai', [
+            'currentFolder' => $folder,
+            'breadcrumbs' => [],
+            'subfolders' => $subfolders,
+            'files' => []
+        ]);
+    }
+
+    public function getStafDokumenKinerjaByWadek()
+    {
+        $user = Auth::user();
+        $role = $user->role;
+
+        if (!in_array($role, ['wadek1', 'wadek2'])) {
+            return response()->json([
+                'error' => 'Access denied'
+            ], 403);
+        }
+
+        $subDivisions = match ($role) {
+            'wadek1' => ['academic_service', 'laboratory'],
+            'wadek2' => ['secretary', 'student_affair', 'finance_logistic_resource'],
+        };
+
+        $subfolders = Folder::where('type', 'kinerja')
+            ->whereHas('user', function ($query) use ($subDivisions) {
+                $query->where('role', 'staf')
+                    ->whereIn('division', $subDivisions);
+            })
+            ->get();
+        $folder = Folder::where('user_id', $user->id)
+            ->where('type', 'user')
+            ->first();
+
+        return Inertia::render('e-archive/staf/kerja', [
+            'currentFolder' => $folder,
+            'breadcrumbs' => [],
+            'subfolders' => $subfolders,
+            'files' => []
+        ]);
+    }
+
+
 
     private function getBreadcrumbs(Folder $folder)
     {

--- a/app/Http/Controllers/FolderController.php
+++ b/app/Http/Controllers/FolderController.php
@@ -235,6 +235,67 @@ class FolderController extends Controller
         ]);
     }
 
+    public function getStafDocumentKerjaByDivision(Request $request)
+    {
+        $user = Auth::user();
+
+        if ($user->role !== 'kaur') {
+            return response()->json([
+                'error' => 'Access denied'
+            ], 403);
+        }
+
+
+        $subfolders = Folder::where('type', 'kinerja')
+            ->whereHas('user', function ($query) use ($user) {
+                $query->where('role', 'staf')
+                    ->where('division', $user->division);
+            })
+            ->get();
+
+        $currentFolder = Folder::where('user_id', $user->id)
+            ->where('type', 'user')
+            ->first();
+
+        return Inertia::render('e-archive/staf/kerja', [
+            'currentFolder' => $currentFolder,
+            'breadcrumbs' => [],
+            'subfolders' => $subfolders,
+            'files' => []
+        ]);
+    }
+
+
+    public function getStafDocumentKepegawaianByDivision(Request $request)
+    {
+        $user = Auth::user();
+
+        if ($user->role !== 'kaur') {
+            return response()->json([
+                'error' => 'Access denied'
+            ], 403);
+        }
+
+
+        $subfolders = Folder::where('type', 'kepegawaian')
+            ->whereHas('user', function ($query) use ($user) {
+                $query->where('role', 'staf')
+                    ->where('division', $user->division);
+            })
+            ->get();
+
+        $currentFolder = Folder::where('user_id', $user->id)
+            ->where('type', 'user')
+            ->first();
+
+        return Inertia::render('e-archive/staf/kerja', [
+            'currentFolder' => $currentFolder,
+            'breadcrumbs' => [],
+            'subfolders' => $subfolders,
+            'files' => []
+        ]);
+    }
+
 
     public function getKaurDokumenKepegawaianByWadek()
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -67,14 +67,14 @@ class User extends Authenticatable
 
             // Create a kepegawaian folder with the user folder as its parent
             $kepegawaianFolder = Folder::create([
-                'name' => 'Kepegawaian',
+                'name' => "Kepegawaian {$user->division}_{$user->username}",
                 'parent_id' => $userFolder->id,
                 'user_id' => $user->id,
                 'type' => 'kepegawaian',
             ]);
 
             $kinerjaFolder = Folder::create([
-                'name' => 'Kinerja',
+                'name' => "Kinerja {$user->division}_{$user->username}",
                 'parent_id' => $userFolder->id,
                 'user_id' => $user->id,
                 'type' => 'kinerja',
@@ -108,13 +108,13 @@ class User extends Authenticatable
         return $this->hasMany(File::class);
     }
 
-    public function workTargets()
-    {
-        return $this->hasMany(WorkTarget::class);
-    }
+    // public function workTargets()
+    // {
+    //     return $this->hasMany(WorkTarget::class);
+    // }
 
-    public function workTargetValues()
-    {
-        return $this->hasMany(WorkTargetValue::class);
-    }
+    // public function workTargetValues()
+    // {
+    //     return $this->hasMany(WorkTargetValue::class);
+    // }
 }

--- a/resources/js/components/sidebar/sidebar.ts
+++ b/resources/js/components/sidebar/sidebar.ts
@@ -259,12 +259,12 @@ export const wadekArsipSections: NavSection[] = [
 			{
 				title: "Dokumen Kerja",
 				icon: FolderIcon,
-				href: "/dashboard/e-archive/staf/kerja",
+				href: "/dashboard/e-archive/staf/wadek/kerja",
 			},
 			{
 				title: "Dokumen Pegawai",
 				icon: FolderIcon,
-				href: "/dashboard/e-archive/staf/pegawai",
+				href: "/dashboard/e-archive/staf/wadek/pegawai",
 			},
 		],
 	},

--- a/resources/js/components/sidebar/sidebar.ts
+++ b/resources/js/components/sidebar/sidebar.ts
@@ -347,12 +347,12 @@ export const tpaArsipSections: NavSection[] = [
 			{
 				title: "Dokumen Kerja",
 				icon: FolderIcon,
-				href: "/dashboard/e-archive",
+				href: "/dashboard/e-archive/kerja",
 			},
 			{
 				title: "Dokumen Pegawai",
 				icon: FolderIcon,
-				href: "/dashboard/e-archive", // TODO:
+				href: "/dashboard/e-archive/pegawai",
 			},
 		],
 	},

--- a/resources/js/components/sidebar/sidebar.ts
+++ b/resources/js/components/sidebar/sidebar.ts
@@ -229,12 +229,12 @@ export const wadekArsipSections: NavSection[] = [
 			{
 				title: "Dokumen Kerja",
 				icon: FolderIcon,
-				href: "/dashboard/e-archive",
+				href: "/dashboard/e-archive/kerja",
 			},
 			{
 				title: "Dokumen Pegawai",
 				icon: FolderIcon,
-				href: "/dashboard/e-archive", // TODO:
+				href: "/dashboard/e-archive/pegawai",
 			},
 		],
 	},
@@ -244,12 +244,12 @@ export const wadekArsipSections: NavSection[] = [
 			{
 				title: "Dokumen Kerja",
 				icon: FolderIcon,
-				href: "/dashboard/e-archive",
+				href: "/dashboard/e-archive/kaur/kerja",
 			},
 			{
 				title: "Dokumen Pegawai",
 				icon: FolderIcon,
-				href: "/dashboard/e-archive", // TODO:
+				href: "/dashboard/e-archive/kaur/pegawai",
 			},
 		],
 	},
@@ -259,12 +259,12 @@ export const wadekArsipSections: NavSection[] = [
 			{
 				title: "Dokumen Kerja",
 				icon: FolderIcon,
-				href: "/dashboard/e-archive",
+				href: "/dashboard/e-archive/staf/kerja",
 			},
 			{
 				title: "Dokumen Pegawai",
 				icon: FolderIcon,
-				href: "/dashboard/e-archive", // TODO:
+				href: "/dashboard/e-archive/staf/pegawai",
 			},
 		],
 	},
@@ -304,12 +304,12 @@ export const kaurArsipSections: NavSection[] = [
 			{
 				title: "Dokumen Kerja",
 				icon: FolderIcon,
-				href: "/dashboard/e-archive",
+				href: "/dashboard/e-archive/kerja",
 			},
 			{
 				title: "Dokumen Pegawai",
 				icon: FolderIcon,
-				href: "/dashboard/e-archive", // TODO:
+				href: "/dashboard/e-archive/pegawai",
 			},
 		],
 	},
@@ -319,12 +319,12 @@ export const kaurArsipSections: NavSection[] = [
 			{
 				title: "Dokumen Kerja",
 				icon: FolderIcon,
-				href: "/dashboard/e-archive",
+				href: "/dashboard/e-archive/staf/kerja",
 			},
 			{
 				title: "Dokumen Pegawai",
 				icon: FolderIcon,
-				href: "/dashboard/e-archive", // TODO:
+				href: "/dashboard/e-archive/staf/pegawai",
 			},
 		],
 	},

--- a/resources/js/pages/e-archive/staf/kerja.tsx
+++ b/resources/js/pages/e-archive/staf/kerja.tsx
@@ -1,0 +1,22 @@
+import { EArchiveProvider } from "@/hooks/use-e-archive";
+import DashboardLayout from "@/layouts/dashboard-layout";
+import EArchiveLayout from "@/layouts/e-archive-layout";
+import type { File, Folder } from "@/types";
+
+export default function EArchiveKinerjaStafPage({
+	currentFolder,
+	subfolders,
+	files,
+}: { currentFolder: Folder; subfolders: Folder[]; files: File[] }) {
+	return (
+		<DashboardLayout header="Arsip">
+			<EArchiveProvider>
+				<EArchiveLayout
+					currentFolder={currentFolder}
+					subfolders={subfolders}
+					files={files}
+				/>
+			</EArchiveProvider>
+		</DashboardLayout>
+	);
+}

--- a/resources/js/pages/e-archive/staf/pegawai.tsx
+++ b/resources/js/pages/e-archive/staf/pegawai.tsx
@@ -1,0 +1,22 @@
+import { EArchiveProvider } from "@/hooks/use-e-archive";
+import DashboardLayout from "@/layouts/dashboard-layout";
+import EArchiveLayout from "@/layouts/e-archive-layout";
+import type { File, Folder } from "@/types";
+
+export default function EArchiveKepegawaianStafPage({
+	currentFolder,
+	subfolders,
+	files,
+}: { currentFolder: Folder; subfolders: Folder[]; files: File[] }) {
+	return (
+		<DashboardLayout header="Arsip">
+			<EArchiveProvider>
+				<EArchiveLayout
+					currentFolder={currentFolder}
+					subfolders={subfolders}
+					files={files}
+				/>
+			</EArchiveProvider>
+		</DashboardLayout>
+	);
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -56,7 +56,7 @@ Route::middleware(['auth', 'role:sdm'])->group(function () {
     // Route::delete('/dashboard/tags/{tag}', [TagController::class, 'destroy'])->name('tags.destroy');
 });
 
-Route::middleware(['auth', 'role:wadek'])->group(function () {
+Route::middleware(['auth', 'role:wadek1,wadek2'])->group(function () {
     Route::get('/dashboard/work-target/kaur', [WorkTargetController::class, 'indexKaur'])->name('dashboard.work-target.kaur');
 
     Route::get('/dashboard/user-attitude-evaluation/kaur', [UserAttitudeEvaluationController::class, 'indexKaur'])->name('dashboard.user-attitude-evaluation.kaur');
@@ -65,6 +65,10 @@ Route::middleware(['auth', 'role:wadek'])->group(function () {
         '/dashboard/work-report/kaur',
         [WorkTargetController::class, 'indexKaur'] // TODO:
     )->name('dashboard.work-report.kaur');
+    Route::get('/dashboard/e-archive/staf/kerja', [FolderController::class, 'getStafDokumenKinerjaByWadek'])
+        ->name('folders.wadek-kerja');
+    Route::get('/dashboard/e-archive/staf/pegawai', [FolderController::class, 'getStafDokumenKepegawaianByWadek'])
+        ->name('folders.wadek-pegawai');
 
     // Route::get('/dashboard/performance/kaur/{id}', [WorkTargetController::class, 'show'])->name('dashboard.performance.kaur.show');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -62,6 +62,10 @@ Route::middleware(['auth', 'role:sdm'])->group(function () {
 });
 
 Route::middleware(['auth', 'role:kaur'])->group(function () {
+    Route::get('/dashboard/e-archive/staf/kerja', [FolderController::class, 'getStafDocumentKerjaByDivision'])
+        ->name('folders.kaur-kerja');
+    Route::get('/dashboard/e-archive/staf/pegawai', [FolderController::class, 'getStafDocumentKepegawaianByDivision'])
+        ->name('folders.kaur-pegawai');
 });
 
 Route::middleware(['auth', 'role:wadek1,wadek2'])->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,12 +35,17 @@ Route::middleware(['auth'])->group(function (): void {
     Route::get('/dashboard/e-archive', [FolderController::class, 'index'])
         ->name('folders.index');
 
-    Route::get('/dashboard/e-archive/{folderId}', [FolderController::class, 'show'])
-        ->name('folders.show');
+
 
     Route::post('/dashboard/e-archive', [FileController::class, 'store'])
         ->name('files.store');
     Route::delete('/dashboard/e-archive/{file}', [FileController::class, 'destroy'])->name('files.destroy');
+    Route::get('/dashboard/e-archive/kerja', [FolderController::class, 'getMyDocumentKinerja'])
+        ->name('folders.earchive.kerja-me');
+    Route::get('/dashboard/e-archive/pegawai', [FolderController::class, 'getMyDocumentKepegawaian'])
+        ->name('folders.earchive.pegawai-me');
+    Route::get('/dashboard/e-archive/{folderId}', [FolderController::class, 'show'])
+        ->name('folders.show');
     // Route::get('/dashboard/weekly-report', [WeeklyReportController::class, 'index'])->name('weekly-report.index');
     // Route::post('/dashboard/weekly-report', [WeeklyReportController::class, 'store'])->name('weekly-report.store');
     // Route::put('/dashboard/weekly-report/{weeklyReport}', [WeeklyReportController::class, 'update'])->name('weekly-report.update');

--- a/routes/web.php
+++ b/routes/web.php
@@ -56,6 +56,9 @@ Route::middleware(['auth', 'role:sdm'])->group(function () {
     // Route::delete('/dashboard/tags/{tag}', [TagController::class, 'destroy'])->name('tags.destroy');
 });
 
+Route::middleware(['auth', 'role:kaur'])->group(function () {
+});
+
 Route::middleware(['auth', 'role:wadek1,wadek2'])->group(function () {
     Route::get('/dashboard/work-target/kaur', [WorkTargetController::class, 'indexKaur'])->name('dashboard.work-target.kaur');
 
@@ -65,11 +68,14 @@ Route::middleware(['auth', 'role:wadek1,wadek2'])->group(function () {
         '/dashboard/work-report/kaur',
         [WorkTargetController::class, 'indexKaur'] // TODO:
     )->name('dashboard.work-report.kaur');
-    Route::get('/dashboard/e-archive/staf/kerja', [FolderController::class, 'getStafDokumenKinerjaByWadek'])
+    Route::get('/dashboard/e-archive/staf/wadek/kerja', [FolderController::class, 'getStafDokumenKinerjaByWadek'])
         ->name('folders.wadek-kerja');
-    Route::get('/dashboard/e-archive/staf/pegawai', [FolderController::class, 'getStafDokumenKepegawaianByWadek'])
+    Route::get('/dashboard/e-archive/staf/wadek/pegawai', [FolderController::class, 'getStafDokumenKepegawaianByWadek'])
         ->name('folders.wadek-pegawai');
-
+    Route::get('/dashboard/e-archive/kaur/kerja', [FolderController::class, 'getKaurDokumenKinerjaByWadek'])
+        ->name('folders.wadek-kerja-kaur');
+    Route::get('/dashboard/e-archive/kaur/pegawai', [FolderController::class, 'getKaurDokumenKepegawaianByWadek'])
+        ->name('folders.wadek-pegawai-kaur');
     // Route::get('/dashboard/performance/kaur/{id}', [WorkTargetController::class, 'show'])->name('dashboard.performance.kaur.show');
 });
 


### PR DESCRIPTION
This pull request introduces significant updates to the `FolderController`, routing, and frontend navigation to enhance document management functionality for different user roles. It also includes changes to the `User` model and new frontend pages for staff document views. Below is a summary of the most important changes grouped by theme.

### Backend Enhancements

* **New Methods in `FolderController`:** Added multiple methods to handle document retrieval based on user roles and document types, including `getMyDocumentKinerja`, `getMyDocumentKepegawaian`, and role-specific methods like `getStafDocumentKerjaByDivision` and `getKaurDokumenKinerjaByWadek`. These methods ensure role-based access and dynamic data rendering for folders and files.
* **Routing Updates:** Introduced new routes in `web.php` for accessing role-specific document views, such as `/dashboard/e-archive/kerja` for personal work documents and `/dashboard/e-archive/staf/wadek/kerja` for staff documents accessible by `wadek`. [[1]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadL38-R48) [[2]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadL59-R71) [[3]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadL68-R87)

### Frontend Updates

* **Sidebar Navigation:** Updated navigation links in `sidebar.ts` to point to the new routes for `kerja` and `pegawai` documents, ensuring alignment with the backend changes. [[1]](diffhunk://#diff-614528c7ec0308bf5dbfa86c525301297129fb01809edd6ea77187d23403c46bL232-R237) [[2]](diffhunk://#diff-614528c7ec0308bf5dbfa86c525301297129fb01809edd6ea77187d23403c46bL247-R252) [[3]](diffhunk://#diff-614528c7ec0308bf5dbfa86c525301297129fb01809edd6ea77187d23403c46bL262-R267) [[4]](diffhunk://#diff-614528c7ec0308bf5dbfa86c525301297129fb01809edd6ea77187d23403c46bL307-R312) [[5]](diffhunk://#diff-614528c7ec0308bf5dbfa86c525301297129fb01809edd6ea77187d23403c46bL322-R327)
* **New Pages for Staff Documents:** Added `EArchiveKinerjaStafPage` and `EArchiveKepegawaianStafPage` to display staff-specific document views, leveraging the `EArchiveProvider` and `EArchiveLayout` components. [[1]](diffhunk://#diff-6d52b5283f068b0bad72a2cc2469a354b0349ecd6ed716b2cc66da983900b537R1-R22) [[2]](diffhunk://#diff-9fc196fd01779ce33fc971ad745f73d084eaf5fd96db7ec9f6eea7769522088fR1-R22)

### Model Adjustments

* **Dynamic Folder Names:** Updated the `User` model to create folders with dynamic names based on the user's division and username (e.g., `Kepegawaian {division}_{username}`). This change improves folder organization.
* **Commented Out Unused Relationships:** Temporarily disabled `workTargets` and `workTargetValues` relationships in the `User` model, likely due to redundancy or pending refactoring.

These changes collectively enhance the system's role-based functionality, improve folder organization, and align the frontend and backend for seamless user experiences.