### PR TITLE
Add period selection dropdown and custom hook for managing periods

### DIFF
--- a/resources/js/hooks/use-period.ts
+++ b/resources/js/hooks/use-period.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+
+const START_YEAR = 2024;
+
+export const usePeriod = () => {
+	const [period, setPeriod] = useState<Date>(new Date());
+
+	const getCurrentYear = () => {
+		return period.getFullYear();
+	};
+
+	const getAvailableYears = () => {
+		const currentYear = new Date().getFullYear();
+		const years = [];
+		for (let year = START_YEAR; year <= currentYear; year++) {
+			years.push(year);
+		}
+		return years;
+	};
+
+	useEffect(() => {
+		const currentYear = period.getFullYear();
+		const url = new URL(window.location.href);
+		url.searchParams.set("period", currentYear.toString());
+		window.history.replaceState({}, "", url.toString());
+	}, [period]);
+
+	return {
+		period,
+		setPeriod,
+		getCurrentYear,
+		getAvailableYears,
+	};
+};

--- a/resources/js/layouts/dashboard-layout.tsx
+++ b/resources/js/layouts/dashboard-layout.tsx
@@ -8,13 +8,22 @@ import {
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { useUser } from "@/hooks/use-user";
 import { Link } from "@inertiajs/react";
-import { LogOut, MenuIcon, User, UserSquareIcon } from "lucide-react";
+import {
+	ChevronDownSquareIcon,
+	LogOut,
+	MenuIcon,
+	User,
+	UserSquareIcon,
+} from "lucide-react";
 import type { PropsWithChildren, ReactNode } from "react";
+import { Button } from "../components/ui/button";
+import { usePeriod } from "../hooks/use-period";
 
 export default function DashboardLayout({
 	children,
 }: PropsWithChildren<{ header?: string | ReactNode }>) {
 	const user = useUser();
+	const { period, setPeriod, getCurrentYear, getAvailableYears } = usePeriod();
 
 	return (
 		<SidebarProvider>
@@ -31,6 +40,24 @@ export default function DashboardLayout({
 								</span>
 							</div>
 							<div className="flex flex-row gap-4 items-center justify-end">
+								<DropdownMenu>
+									<DropdownMenuTrigger asChild>
+										<Button variant="ghost" className="text-xs h-min">
+											Periode: {getCurrentYear()}
+											<ChevronDownSquareIcon />
+										</Button>
+									</DropdownMenuTrigger>
+									<DropdownMenuContent>
+										{getAvailableYears().map((year) => (
+											<DropdownMenuItem
+												key={year}
+												onClick={() => setPeriod(new Date(year, 0, 1))}
+											>
+												{year}
+											</DropdownMenuItem>
+										))}
+									</DropdownMenuContent>
+								</DropdownMenu>
 								<span className="text-xs text-[#98A2B3]">{user.name}</span>
 								<DropdownMenu>
 									<DropdownMenuTrigger asChild>


### PR DESCRIPTION
Introduce a dropdown for selecting periods and a custom hook to manage period state and available years. This enhances the dashboard layout by allowing users to easily select and update the displayed period.